### PR TITLE
particles sorting, "Shaken, not stirred"

### DIFF
--- a/src/starling/extensions/ParticleSystem.as
+++ b/src/starling/extensions/ParticleSystem.as
@@ -238,9 +238,10 @@ package starling.extensions
                 {
                     if (particleIndex != mNumParticles - 1)
                     {
-                        var nextParticle:Particle = mParticles[int(mNumParticles-1)] as Particle;
-                        mParticles[int(mNumParticles-1)] = particle;
-                        mParticles[particleIndex] = nextParticle;
+                        mParticles.fixed = false;
+                        mParticles.splice(particleIndex, 1);
+                        mParticles[mParticles.length] = particle;
+                        mParticles.fixed = true;
                     }
                     
                     --mNumParticles;


### PR DESCRIPTION
if i want to do trail effect, but some new initialized particles rendered under oldest

white rectangle is a head

before
![](http://i.minus.com/iberGmKMdXUI0L.png)

after
![](http://i.minus.com/iWZ0c9vyZUS2T.png)
