### PR TITLE
init ParticleSystem with particles already part way through their life spans

### DIFF
--- a/src/starling/extensions/ParticleSystem.as
+++ b/src/starling/extensions/ParticleSystem.as
@@ -369,6 +369,27 @@ package starling.extensions
             context.setVertexBufferAt(1, null);
             context.setVertexBufferAt(2, null);
         }
+		
+		/**
+		 * Initialize the <tt>ParticleSystem</tt> with Particles distributed randomly throughout their lifespans.
+		 */
+		public function populateSystem(numParticlesToPopulate:int):void
+		{
+			numParticlesToPopulate = Math.min(numParticlesToPopulate, mMaxCapacity);
+			if (numParticlesToPopulate > capacity)
+			{
+				raiseCapacity(numParticlesToPopulate - capacity);
+			}
+			
+			var p:Particle;
+			for (var i:int=0; i<numParticlesToPopulate; i++)
+			{
+				p = mParticles[i];
+				initParticle(p);
+				advanceParticle(p, Math.random() * p.totalTime);
+			}
+			mNumParticles += numParticlesToPopulate;
+		}
         
         // program management
         


### PR DESCRIPTION
in response to [this tutorial on the Starling wiki](http://wiki.starling-framework.org/tutorials/create_stars_background) and this [pull request](https://github.com/PrimaryFeather/Starling-Extension-Particle-System/pull/10), i propose adding just one method to ParticleSystem.

doesn't require exposing any members or any significant overhaul, just starts up the ParticleSystem with a specified number of Particles already part way through their life spans.
