### PR TITLE
populate() from end of particle array rather than beginning  in order to avoid overwriting active particles

### DIFF
--- a/src/starling/extensions/ParticleSystem.as
+++ b/src/starling/extensions/ParticleSystem.as
@@ -381,7 +381,7 @@ package starling.extensions
             var p:Particle;
             for (var i:int=0; i<count; i++)
             {
-                p = mParticles[i];
+                p = mParticles[mNumParticles+i];
                 initParticle(p);
                 advanceParticle(p, Math.random() * p.totalTime);
             }


### PR DESCRIPTION
in order to avoid overwriting active particles.
