### PR TITLE
possible memory leak

### DIFF
--- a/src/starling/extensions/ParticleSystem.as
+++ b/src/starling/extensions/ParticleSystem.as
@@ -35,7 +35,7 @@ package starling.extensions
     import starling.utils.VertexData;
     
     /** Dispatched when emission of particles is finished. */
-    [Event(name="complete", type="starling.events.Event")]
+    [Event(name="removeFromJuggler", type="starling.events.Event")]
     
     public class ParticleSystem extends DisplayObject implements IAnimatable
     {
@@ -251,7 +251,7 @@ package starling.extensions
                     --mNumParticles;
                     
                     if (mNumParticles == 0 && mEmissionTime == 0)
-                        dispatchEvent(new Event(Event.COMPLETE));
+                        dispatchEvent(new Event(Event.REMOVE_FROM_JUGGLER));
                 }
             }
             


### PR DESCRIPTION
change the event that will be dispatched when emission of particles is finished from "COMPLETE" to "REMOVE_FROM_JUGGLER".

if someone wrote
<code>Starling.juggler.add(mParticleSystem);</code>
but didn't remove manually like this
<code>Starling.juggler.remove(mParticleSystem);</code>
that will cause memory leak.

and other objects that can be added to juggler are not require remove manually.
