### PR TITLE
Blend Mode: fixed blend mode & enabled BlendMode.AUTO for base particle system

### DIFF
--- a/src/starling/extensions/ParticleSystem.as
+++ b/src/starling/extensions/ParticleSystem.as
@@ -49,8 +49,6 @@ package starling.extensions
         private var _emissionTime:Number;
         private var _emitterX:Number;
         private var _emitterY:Number;
-        private var _blendFactorSource:String;
-        private var _blendFactorDestination:String;
 
         // smoothed emitter positions
         private var _emitterNextX:Number;
@@ -74,14 +72,10 @@ package starling.extensions
             _emitterNextX = _emitterNextY = 0.0;
             _emissionTime = 0.0;
             _emissionRate = 10;
-            _blendFactorSource = Context3DBlendFactor.ONE;
-            _blendFactorDestination = Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA;
             _batchable = false;
 
             this.capacity = 128;
             this.texture = texture;
-
-            updateBlendMode();
         }
 
         /** @inheritDoc */
@@ -95,36 +89,6 @@ package starling.extensions
         override public function hitTest(localPoint:Point):DisplayObject
         {
             return null;
-        }
-
-        private function updateBlendMode():void
-        {
-            var pma:Boolean = texture ? texture.premultipliedAlpha : true;
-
-            // Particle Designer uses special logic for a certain blend factor combination
-            if (_blendFactorSource == Context3DBlendFactor.ONE &&
-                _blendFactorDestination == Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA)
-            {
-                _vertexData.premultipliedAlpha = pma;
-                if (!pma) _blendFactorSource = Context3DBlendFactor.SOURCE_ALPHA;
-            }
-            else
-            {
-                _vertexData.premultipliedAlpha = false;
-            }
-
-            // When the default normal blend combination is used, use BlendMode.NORMAL instead
-            // of registering a new blendMode - that way, textures can be batched together
-            if (_blendFactorSource == Context3DBlendFactor.ONE &&
-                _blendFactorDestination == Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA)
-            {
-                blendMode = BlendMode.NORMAL
-            }
-            else
-            {
-                blendMode = _blendFactorSource + ", " + _blendFactorDestination;
-                BlendMode.register(blendMode, _blendFactorSource, _blendFactorDestination);
-            }
         }
         
         protected function createParticle():Particle
@@ -449,20 +413,6 @@ package starling.extensions
          *  This provides homogeneous particle distribution in situations with a low frame rate. */
         public function get emitterNextY():Number { return _emitterNextY; }
         public function set emitterNextY(value:Number):void { _emitterNextY = value; }
-
-        public function get blendFactorSource():String { return _blendFactorSource; }
-        public function set blendFactorSource(value:String):void
-        {
-            _blendFactorSource = value;
-            updateBlendMode();
-        }
-        
-        public function get blendFactorDestination():String { return _blendFactorDestination; }
-        public function set blendFactorDestination(value:String):void
-        {
-            _blendFactorDestination = value;
-            updateBlendMode();
-        }
         
         override public function set texture(value:Texture):void
         {
@@ -476,8 +426,6 @@ package starling.extensions
                     value.setupTextureCoordinates(_vertexData, i);
                 }
             }
-
-            updateBlendMode();
         }
 
         override public function setStyle(meshStyle:MeshStyle=null,


### PR DESCRIPTION
Hi Daniel,

Here is a proposal or just a starting base to discuss. This PR is doing the following:

- Moving `_blendFactorSource` & `_blendFactorDestination` from `ParticleSystem` to `PDParticleSystem`
- Improving official blend mode detection from blend factors for better batching
- Removing blend mode adjustment from texture `PMA` flag

Looking forward to have your feedback on it 🙂

Best,
Aurélien


PS: Please note that there are two TODOs remaining in it.