### PR TITLE
Allow starling to skip frames

### DIFF
--- a/src/starling/extensions/ParticleSystem.as
+++ b/src/starling/extensions/ParticleSystem.as
@@ -200,12 +200,10 @@ package starling.extensions
         
         public function advanceTime(passedTime:Number):void
         {
-            setRequiresRedraw();
-            setRequiresSync();
-
             var particleIndex:int = 0;
             var particle:Particle;
             var maxNumParticles:int = capacity;
+            var numParticlesBefore:int = _numParticles;
             
             // advance existing particles
 
@@ -332,6 +330,12 @@ package starling.extensions
                     _vertexData.setPoint(vertexID+2, "position", x - offsetX, y + offsetY);
                     _vertexData.setPoint(vertexID+3, "position", x + offsetX, y + offsetY);
                 }
+            }
+
+            // Allow starling skip the frame when there is no active particles.
+            if (_numParticles > 0 || numParticlesBefore > 0) {
+                setRequiresRedraw();
+                setRequiresSync();
             }
         }
 


### PR DESCRIPTION
When the particle system contains no active particles, requesting a redraw
prevents Starling from skipping the frame.

This implementation checks that no particles existed neither before nor after
the simulation step. It doesn't request a redraw when this is the case.